### PR TITLE
Use primary dataset as default for secondary

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -43,8 +43,8 @@ flags.DEFINE_string(
 )
 flags.DEFINE_string(
     "secondary_dataset_name",
-    "svhn",
-    "Name of dataset containing secondary data.",
+    "",
+    "Name of dataset containing secondary data. Defaults to primary dataset",
 )
 flags.DEFINE_integer("label_map_index", 0, "Index of the label map.")
 flags.DEFINE_integer(
@@ -146,7 +146,9 @@ def train(hps, result_dir, tuner=None, trial_name=None):
 
         images, labels, _, _, _, _ = data_provider.get_simple_mixed_batch(
             labeled_dataset_name=FLAGS.primary_dataset_name,
-            unlabeled_dataset_name=FLAGS.secondary_dataset_name,
+            unlabeled_dataset_name=(
+                FLAGS.secondary_dataset_name or
+                FLAGS.primary_dataset_name),
             split="train",
             batch_size=FLAGS.batch_size,
             shuffle_buffer_size=1000,


### PR DESCRIPTION
The common case in runs is to use the same dataset for primary and
secondary.