### PR TITLE
Use -1 as default for n_labeled

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -48,7 +48,7 @@ flags.DEFINE_string(
 )
 flags.DEFINE_integer("label_map_index", 0, "Index of the label map.")
 flags.DEFINE_integer(
-    "n_labeled", 10000, "Number of labeled examples, or -1 for entire dataset."
+    "n_labeled", -1, "Number of labeled examples, or -1 for entire dataset."
 )
 flags.DEFINE_integer(
     "training_length", 500000, "number of steps to train for."


### PR DESCRIPTION
When n_labeled is not -1, train requires a label map named
`label_map_count_N_index_0`. The previous default value of 10000 is
not supported under `data`.

Using -1 avoids having to provide a label map in the default case.