### PR TITLE
Mark global_step_init as used to prevent spurious warning msg

### DIFF
--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -198,6 +198,7 @@ def evaluate(hps, result_dir, tuner=None, trial_name=None):
                 consistency_model=FLAGS.consistency_model,
                 zca_input_file_path=FLAGS.zca_input_file_path,
             )
+            ssl_framework.global_step_init.mark_used()
             new_saver = tf.train.Saver(tf.global_variables())
 
             # We need a new session for each checkpoint


### PR DESCRIPTION
Without this, TF displays a warning message that looks like an
error (contains traceback):

```
E1121 12:34:00.888499 139860141586240 tf_logging.py:105] ==================================
Object was never used (type <class 'tensorflow.python.framework.ops.Operation'>):
<tf.Operation 'init' type=NoOp>
If you want to mark it as used call its "mark_used()" method.
It was originally created here:
  ...
```

This behavior occurs on TF 1.12.0 but reports suggest that these
warnings started appearing as early as TF 1.2.0.